### PR TITLE
INC1-227 feet: add card

### DIFF
--- a/src/shared/components/ui/card/Card.module.scss
+++ b/src/shared/components/ui/card/Card.module.scss
@@ -1,0 +1,81 @@
+.card {
+  width: 100%;
+  height: 100%;
+  background-color: var(--color-dark-500);
+  border: 2px solid var(--color-dark-300);
+
+  &.sm {
+    max-height: 72px;
+  }
+
+  &.md {
+    max-height: 96px;
+  }
+
+  &.lg {
+    max-height: 120px;
+  }
+
+  &.flex {
+    display: flex;
+
+    &.center {
+      justify-content: center;
+    }
+
+    &.columnCenter {
+      flex-direction: column;
+      align-items: center;
+    }
+
+    &.spaceBetween {
+      justify-content: space-between;
+    }
+
+    &.spaceBetweenCenter {
+      justify-content: space-between;
+      align-items: center;
+    }
+  }
+}
+
+.card {
+  width: 100%;
+  height: 100%;
+  background-color: var(--color-dark-500);
+  border: 2px solid var(--color-dark-300);
+
+  &.sm {
+    max-height: 72px;
+  }
+
+  &.md {
+    max-height: 96px;
+  }
+
+  &.lg {
+    max-height: 120px;
+  }
+
+  &.flex {
+    display: flex;
+
+    &.center {
+      justify-content: center;
+    }
+
+    &.columnCenter {
+      flex-direction: column;
+      align-items: center;
+    }
+
+    &.spaceBetween {
+      justify-content: space-between;
+    }
+
+    &.spaceBetweenCenter {
+      justify-content: space-between;
+      align-items: center;
+    }
+  }
+}

--- a/src/shared/components/ui/card/Card.tsx
+++ b/src/shared/components/ui/card/Card.tsx
@@ -1,0 +1,39 @@
+import { ComponentPropsWithoutRef, ReactNode } from 'react'
+
+import clsx from 'clsx'
+
+import s from './Card.module.scss'
+
+type Props = {
+  children?: ReactNode
+  /**
+   * Максимальная высота компонента.
+   * Может быть одним из стандартных значений: 'sm', 'md', 'lg'.
+   *
+   * - 'sm' — 72px
+   * - 'md' — 96px
+   * - 'lg' — 120px
+   */
+  size?: 'sm' | 'md' | 'lg'
+  /**
+   * Настройка флекс-вирівнювання для компонента.
+   * Определяет способ выравнивания элементов внутри flex-контейнера.
+   *
+   * Возможные значения:
+   * - 'center' — горизонтальное центрирование (justify-content: center)
+   * - 'columnCenter' — вертикальное расположение с центрированием (flex-direction: column + align-items: center)
+   * - 'spaceBetween' — элементы распределены с пробелами между (justify-content: space-between)
+   * - 'spaceBetweenCenter' — элементы с пробелами между и вертикальным центрированием (justify-content: space-between + align-items: center)
+   */
+  flex?: 'center' | 'columnCenter' | 'spaceBetween' | 'spaceBetweenCenter'
+} & ComponentPropsWithoutRef<'div'>
+
+export const Card = ({ children, size = 'md', flex, className, ...rest }: Props) => {
+  const cardStyles = clsx(s.card, flex && [s.flex, s[flex]], s[size])
+
+  return (
+    <div className={clsx(cardStyles, className)} {...rest}>
+      {children}
+    </div>
+  )
+}

--- a/src/shared/components/ui/index.ts
+++ b/src/shared/components/ui/index.ts
@@ -1,0 +1,1 @@
+export * from './card/Card'


### PR DESCRIPTION
### Компонент `Card`

#### Обновления:
- Добавлен переиспользуемый компонент карточки `Card`.
- Поддерживает переданное содержимое через `children`.
- Принимает необязательный проп `size` с предустановленными размерами по высоте:
  - `sm` — 72px  
  - `md` — 96px (по умолчанию)  
  - `lg` — 120px
- Поддерживает настройку выравнивания через проп `flex`:
  - `center` — горизонтальное центрирование  
  - `columnCenter` — вертикальное расположение и центрирование  
  - `spaceBetween` — распределение элементов с пробелами между ними  
  - `spaceBetweenCenter` — распределение с пробелами + вертикальное центрирование
