### PR TITLE
INC1-237 refactor: remove height container 

### DIFF
--- a/src/shared/components/ui/card/Card.module.scss
+++ b/src/shared/components/ui/card/Card.module.scss
@@ -1,6 +1,5 @@
 .card {
   width: 100%;
-  height: 100%;
   border: 2px solid var(--color-dark-300);
   background-color: var(--color-dark-500);
 

--- a/src/shared/components/ui/card/Card.tsx
+++ b/src/shared/components/ui/card/Card.tsx
@@ -28,8 +28,8 @@ type Props = {
   flex?: 'center' | 'columnCenter' | 'spaceBetween' | 'spaceBetweenCenter'
 } & ComponentPropsWithoutRef<'div'>
 
-export const Card = ({ children, size = 'md', flex, className, ...rest }: Props) => {
-  const cardStyles = clsx(s.card, flex && [s.flex, s[flex]], s[size])
+export const Card = ({ children, size, flex, className, ...rest }: Props) => {
+  const cardStyles = clsx(s.card, flex && [s.flex, s[flex]], size && s[size])
 
   return (
     <div className={clsx(cardStyles, className)} {...rest}>


### PR DESCRIPTION
**Компонент Card**  
- Удалён `height: 100%` у контейнера для улучшения адаптивности.  
- Значение size теперь применяется после условного рендеринга.

Теперь компонент более универсальный и удобный для повторного использования с разными размерами и расположением содержимого.